### PR TITLE
(SIMP-5306) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Sep 05 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.0.3-0
+- Updated $app_pki_external_source to accept any string.  This matches the functionality
+  of pki::copy.
+
 * Tue Jul 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.3-0
 - Support for Puppet5/OEL
 - fixed htaccess tests for Gitlab

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -68,7 +68,7 @@ class simp_apache::ssl (
   String                        $sslverifyclient         = 'require',
   Integer                       $sslverifydepth          = 10,
   Variant[Boolean,Enum['simp']] $pki                     = simplib::lookup('simp_options::pki', { 'default_value' => false }),
-  Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                        $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::AbsolutePath          $app_pki_dir             = '/etc/pki/simp_apps/simp_apache/x509',
   Stdlib::AbsolutePath          $app_pki_ca_dir          = "${app_pki_dir}/cacerts",
   Stdlib::AbsolutePath          $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",


### PR DESCRIPTION
- $app_pki_external_source now accepts any string.  This matches the functionality
  of pki::copy.

SIMP-5296 #comment Updated simp_apache
SIMP-5306 #close