### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
 #-----------------------------------------------------------------------
 
 .pup_4: &pup_4
-  image: 'ruby:2.4'
+  image: 'ruby:2.1'
   variables:
     PUPPET_VERSION: '~> 4.0'
     MATRIX_RUBY_VERSION: '2.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Wed Feb 13 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+- Use simplib::nets2cidr in simp_apache::munge_httpd_networks in
+  in lieu of nets2cidr(), a deprecated simplib Puppet 3 function.
+- Use simplib::ipaddresses in lieu of ipaddresses(), a deprecated
+  simplib Puppet 3 function.
+
 * Fri Oct 12 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Added $package_ensure parameters to simp_apache::install
   - $httpd_ensure  $mod_ldap_ensure  $mod_ssl_ensure

--- a/lib/puppet/functions/simp_apache/munge_httpd_networks.rb
+++ b/lib/puppet/functions/simp_apache/munge_httpd_networks.rb
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:'simp_apache::munge_httpd_networks') do
       if x =~ /^0\.0\.0\.0/
         httpd_networks << 'ALL'
       elsif x =~ /\/\d{1,3}\./
-        httpd_networks << call_function('nets2cidr', x)
+        httpd_networks << call_function('simplib::nets2cidr', x)
       else
         httpd_networks << x
       end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,7 +134,7 @@ class simp_apache (
     $_downcase_os_name = downcase($facts['os']['name'])
     rsync { 'site':
       user     => "apache_rsync_${::environment}_${_downcase_os_name}",
-      password => passgen("apache_rsync_${::environment}_${_downcase_os_name}"),
+      password => simplib::passgen("apache_rsync_${::environment}_${_downcase_os_name}"),
       source   => $rsync_source,
       target   => '/var',
       server   => $rsync_server,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_apache",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "simp/pki",

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe 'simp_apache::conf' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts
+          os_facts
         end
+
+        let(:expected_dir) { File.join(File.dirname(__FILE__), 'expected') }
 
         context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
@@ -14,6 +16,15 @@ describe 'simp_apache::conf' do
           it { is_expected.not_to create_iptables__listen__tcp_stateful('allow_http') }
           it { is_expected.to_not create_rsyslog__rule__local('XX_apache_error') }
           it { is_expected.to_not create_rsyslog__rule__local('YY_apache_access') }
+          it do
+            expected_file = File.join(expected_dir, "httpd.conf_default_el#{facts[:os][:release][:major]}")
+            is_expected.to create_file('/etc/httpd/conf/httpd.conf').with(
+              :owner   => 'root',
+              :group   => 'apache',
+              :mode    => '0640',
+              :content => IO.read(expected_file)
+            )
+          end
         end
 
         context 'firewall = true' do

--- a/spec/classes/expected/httpd.conf_default_el6
+++ b/spec/classes/expected/httpd.conf_default_el6
@@ -1,11 +1,3 @@
-<%
-  t_allowroot = nil
-  if @l_allowroot != 'nil'
-    t_allowroot = Array(@l_allowroot).map{ |x|
-      x = "    Allow from #{x}"
-    }.join("\n")
-  end
--%>
 TraceEnable off
 ServerTokens ProductOnly
 
@@ -14,53 +6,50 @@ ServerRoot "/etc/httpd"
 PidFile run/httpd.pid
 
 # Default: 120
-Timeout <%= @httpd_timeout %>
+Timeout 120
 
 # Default: Off
-KeepAlive <%= @keepalive ? 'On' : 'Off' %>
+KeepAlive Off
 
 # Default: 100
-MaxKeepAliveRequests <%= @maxkeepalive %>
+MaxKeepAliveRequests 100
 
 # Default: 15
-KeepAliveTimeout <%= @keepalivetimeout %>
+KeepAliveTimeout 15
 
 <IfModule prefork.c>
 # Default: 8
-StartServers         <%= @prefork_startservers %>
+StartServers         8
 # Default: 5
-MinSpareServers      <%= @prefork_minspareservers %>
+MinSpareServers      5
 # Default: 20
-MaxSpareServers      <%= @prefork_maxspareservers %>
+MaxSpareServers      20
 # Default: 256
-ServerLimit          <%= @prefork_serverlimit %>
+ServerLimit          3000
 # Default: 256
-MaxClients           <%= @prefork_maxclients %>
+MaxClients           3000
 # Default: 4000
-MaxRequestsPerChild  <%= @prefork_maxrequestsperchild %>
+MaxRequestsPerChild  4000
 </IfModule>
 
 <IfModule worker.c>
 # Default: 2
-StartServers         <%= @worker_startservers %>
+StartServers         2
 # Default: 150
-MaxClients           <%= @worker_maxclients %>
+MaxClients           3000
 # Default: 25
-MinSpareThreads      <%= @worker_minsparethreads %>
+MinSpareThreads      25
 # Default: 75
-MaxSpareThreads      <%= @worker_maxsparethreads %>
+MaxSpareThreads      75
 # Default: 25
-ThreadsPerChild      <%= @worker_threadsperchild %>
+ThreadsPerChild      25
 # Default: 0
-MaxRequestsPerChild  <%= @worker_maxrequestsperchild %>
+MaxRequestsPerChild  0
 </IfModule>
 
 # Default: 80
-<% @listen.flatten.each do |l| -%>
-Listen <%= scope.function_bracketize([l.to_s]) %>
-<% end -%>
+Listen 80
 
-<% if (['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'7']) < 0 -%>
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule include_module modules/mod_include.so
@@ -90,15 +79,8 @@ LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
-<%   if ( ['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'6']) < 0 -%>
-LoadModule cache_module modules/mod_cache.so
-LoadModule file_cache_module modules/mod_file_cache.so
-LoadModule disk_cache_module modules/mod_disk_cache.so
-LoadModule mem_cache_module modules/mod_mem_cache.so
-<%   end -%>
 LoadModule suexec_module modules/mod_suexec.so
 LoadModule cgi_module modules/mod_cgi.so
-<%   if ( ['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'4']) > 0 -%>
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_alias_module modules/mod_authn_alias.so
@@ -116,39 +98,16 @@ LoadModule logio_module modules/mod_logio.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
 LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
 LoadModule version_module modules/mod_version.so
-<%   elsif ['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) -%>
-LoadModule access_module modules/mod_access.so
-LoadModule auth_module modules/mod_auth.so
-LoadModule auth_anon_module modules/mod_auth_anon.so
-LoadModule auth_dbm_module modules/mod_auth_dbm.so
-LoadModule auth_ldap_module modules/mod_auth_ldap.so
-LoadModule cern_meta_module modules/mod_cern_meta.so
-LoadModule asis_module modules/mod_asis.so
-LoadModule imap_module modules/mod_imap.so
-<%   end -%>
-<% else -%>
-Include conf.modules.d/*.conf
-<% end -%>
 
 Include conf.d/*.conf
-<% unless @includes.nil? -%>
-<%    @includes.each do |i| -%>
-Include <%= i %><%= "\n" %>
-<%    end -%>
-<% end -%>
 
-User <%= @user %>
-Group <%= @group %>
+User apache
+Group apache
 
 # Default: root@localhost
-ServerAdmin <%= @serveradmin %>
+ServerAdmin root@localhost
 
-<% unless @servername.nil? -%>
-ServerName <%= @servername %>
-UseCanonicalName On
-<% else -%>
 UseCanonicalName Off
-<% end -%>
 
 DocumentRoot "/var/www/html"
 
@@ -163,12 +122,10 @@ DocumentRoot "/var/www/html"
     AllowOverride None
     Order allow,deny
     Allow from ::1
-<% scope.call_function('simplib::ipaddresses',[]).each do |t_iface| -%>
-    Allow from <%= t_iface %>
-<% end -%>
-<% if t_allowroot -%>
-<%= t_allowroot %>
-<% end -%>
+    Allow from 10.0.2.15
+    Allow from 127.0.0.1
+    Allow from 127.0.0.1
+    Allow from ::1
 
 </Directory>
 
@@ -234,25 +191,23 @@ AccessFileName .htaccess
 
 <IfVersion < 2.4>
 # Default: text/plain
-DefaultType <%= @defaulttype %>
+DefaultType text/plain
 </IfVersion>
 HostnameLookups Off
 
 # Default: on
-EnableMMAP <%= @enablemmap ? 'On' : 'Off' %>
+EnableMMAP On
 
 # Default: on
-EnableSendfile <%= @enablesendfile ? 'On' : 'Off' %>
+EnableSendfile On
 
-ErrorLog syslog:<%= @logfacility %>
+ErrorLog syslog:local6
 
-LogLevel <%= @httpd_loglevel %>
+LogLevel warn
 
-<% unless @logformat.empty? -%>
-LogFormat "<%= @logformat %>" custom
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" custom
 
 CustomLog "|/bin/logger -thttpd -plocal6.notice" custom
-<% end -%>
 
 ServerSignature Off
 
@@ -263,12 +218,10 @@ Alias /icons/ "/var/www/icons/"
     AllowOverride None
     Order allow,deny
     Allow from ::1
-<% scope.call_function('simplib::ipaddresses',[]).each do |t_iface| -%>
-    Allow from <%= t_iface %>
-<% end -%>
-<% if t_allowroot -%>
-<%= t_allowroot %>
-<% end -%>
+    Allow from 10.0.2.15
+    Allow from 127.0.0.1
+    Allow from 127.0.0.1
+    Allow from ::1
 </Directory>
 
 <Directory "/var/www/cgi-bin">
@@ -276,12 +229,10 @@ Alias /icons/ "/var/www/icons/"
     Options +ExecCGI -FollowSymLinks
     Order allow,deny
     Allow from ::1
-<% scope.call_function('simplib::ipaddresses',[]).each do |t_iface| -%>
-    Allow from <%= t_iface %>
-<% end -%>
-<% if t_allowroot -%>
-<%= t_allowroot %>
-<% end -%>
+    Allow from 10.0.2.15
+    Allow from 127.0.0.1
+    Allow from 127.0.0.1
+    Allow from ::1
 </Directory>
 
 IndexOptions FancyIndexing VersionSort NameWidth=*

--- a/spec/classes/expected/httpd.conf_default_el7
+++ b/spec/classes/expected/httpd.conf_default_el7
@@ -1,11 +1,3 @@
-<%
-  t_allowroot = nil
-  if @l_allowroot != 'nil'
-    t_allowroot = Array(@l_allowroot).map{ |x|
-      x = "    Allow from #{x}"
-    }.join("\n")
-  end
--%>
 TraceEnable off
 ServerTokens ProductOnly
 
@@ -14,141 +6,61 @@ ServerRoot "/etc/httpd"
 PidFile run/httpd.pid
 
 # Default: 120
-Timeout <%= @httpd_timeout %>
+Timeout 120
 
 # Default: Off
-KeepAlive <%= @keepalive ? 'On' : 'Off' %>
+KeepAlive Off
 
 # Default: 100
-MaxKeepAliveRequests <%= @maxkeepalive %>
+MaxKeepAliveRequests 100
 
 # Default: 15
-KeepAliveTimeout <%= @keepalivetimeout %>
+KeepAliveTimeout 15
 
 <IfModule prefork.c>
 # Default: 8
-StartServers         <%= @prefork_startservers %>
+StartServers         8
 # Default: 5
-MinSpareServers      <%= @prefork_minspareservers %>
+MinSpareServers      5
 # Default: 20
-MaxSpareServers      <%= @prefork_maxspareservers %>
+MaxSpareServers      20
 # Default: 256
-ServerLimit          <%= @prefork_serverlimit %>
+ServerLimit          3000
 # Default: 256
-MaxClients           <%= @prefork_maxclients %>
+MaxClients           3000
 # Default: 4000
-MaxRequestsPerChild  <%= @prefork_maxrequestsperchild %>
+MaxRequestsPerChild  4000
 </IfModule>
 
 <IfModule worker.c>
 # Default: 2
-StartServers         <%= @worker_startservers %>
+StartServers         2
 # Default: 150
-MaxClients           <%= @worker_maxclients %>
+MaxClients           3000
 # Default: 25
-MinSpareThreads      <%= @worker_minsparethreads %>
+MinSpareThreads      25
 # Default: 75
-MaxSpareThreads      <%= @worker_maxsparethreads %>
+MaxSpareThreads      75
 # Default: 25
-ThreadsPerChild      <%= @worker_threadsperchild %>
+ThreadsPerChild      25
 # Default: 0
-MaxRequestsPerChild  <%= @worker_maxrequestsperchild %>
+MaxRequestsPerChild  0
 </IfModule>
 
 # Default: 80
-<% @listen.flatten.each do |l| -%>
-Listen <%= scope.function_bracketize([l.to_s]) %>
-<% end -%>
+Listen 80
 
-<% if (['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'7']) < 0 -%>
-LoadModule auth_digest_module modules/mod_auth_digest.so
-LoadModule ldap_module modules/mod_ldap.so
-LoadModule include_module modules/mod_include.so
-LoadModule log_config_module modules/mod_log_config.so
-LoadModule env_module modules/mod_env.so
-LoadModule mime_magic_module modules/mod_mime_magic.so
-LoadModule expires_module modules/mod_expires.so
-LoadModule deflate_module modules/mod_deflate.so
-LoadModule headers_module modules/mod_headers.so
-LoadModule usertrack_module modules/mod_usertrack.so
-LoadModule setenvif_module modules/mod_setenvif.so
-LoadModule mime_module modules/mod_mime.so
-#LoadModule dav_module modules/mod_dav.so
-LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
-LoadModule info_module modules/mod_info.so
-#LoadModule dav_fs_module modules/mod_dav_fs.so
-LoadModule vhost_alias_module modules/mod_vhost_alias.so
-LoadModule negotiation_module modules/mod_negotiation.so
-LoadModule dir_module modules/mod_dir.so
-LoadModule actions_module modules/mod_actions.so
-LoadModule speling_module modules/mod_speling.so
-#LoadModule userdir_module modules/mod_userdir.so
-LoadModule alias_module modules/mod_alias.so
-LoadModule rewrite_module modules/mod_rewrite.so
-LoadModule proxy_module modules/mod_proxy.so
-LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-LoadModule proxy_http_module modules/mod_proxy_http.so
-LoadModule proxy_connect_module modules/mod_proxy_connect.so
-<%   if ( ['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'6']) < 0 -%>
-LoadModule cache_module modules/mod_cache.so
-LoadModule file_cache_module modules/mod_file_cache.so
-LoadModule disk_cache_module modules/mod_disk_cache.so
-LoadModule mem_cache_module modules/mod_mem_cache.so
-<%   end -%>
-LoadModule suexec_module modules/mod_suexec.so
-LoadModule cgi_module modules/mod_cgi.so
-<%   if ( ['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'4']) > 0 -%>
-LoadModule auth_basic_module modules/mod_auth_basic.so
-LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_alias_module modules/mod_authn_alias.so
-LoadModule authn_anon_module modules/mod_authn_anon.so
-LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule authn_default_module modules/mod_authn_default.so
-LoadModule authz_host_module modules/mod_authz_host.so
-LoadModule authz_user_module modules/mod_authz_user.so
-LoadModule authz_owner_module modules/mod_authz_owner.so
-LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
-LoadModule authz_dbm_module modules/mod_authz_dbm.so
-LoadModule authz_default_module modules/mod_authz_default.so
-LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
-LoadModule logio_module modules/mod_logio.so
-LoadModule ext_filter_module modules/mod_ext_filter.so
-LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
-LoadModule version_module modules/mod_version.so
-<%   elsif ['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) -%>
-LoadModule access_module modules/mod_access.so
-LoadModule auth_module modules/mod_auth.so
-LoadModule auth_anon_module modules/mod_auth_anon.so
-LoadModule auth_dbm_module modules/mod_auth_dbm.so
-LoadModule auth_ldap_module modules/mod_auth_ldap.so
-LoadModule cern_meta_module modules/mod_cern_meta.so
-LoadModule asis_module modules/mod_asis.so
-LoadModule imap_module modules/mod_imap.so
-<%   end -%>
-<% else -%>
 Include conf.modules.d/*.conf
-<% end -%>
 
 Include conf.d/*.conf
-<% unless @includes.nil? -%>
-<%    @includes.each do |i| -%>
-Include <%= i %><%= "\n" %>
-<%    end -%>
-<% end -%>
 
-User <%= @user %>
-Group <%= @group %>
+User apache
+Group apache
 
 # Default: root@localhost
-ServerAdmin <%= @serveradmin %>
+ServerAdmin root@localhost
 
-<% unless @servername.nil? -%>
-ServerName <%= @servername %>
-UseCanonicalName On
-<% else -%>
 UseCanonicalName Off
-<% end -%>
 
 DocumentRoot "/var/www/html"
 
@@ -163,12 +75,10 @@ DocumentRoot "/var/www/html"
     AllowOverride None
     Order allow,deny
     Allow from ::1
-<% scope.call_function('simplib::ipaddresses',[]).each do |t_iface| -%>
-    Allow from <%= t_iface %>
-<% end -%>
-<% if t_allowroot -%>
-<%= t_allowroot %>
-<% end -%>
+    Allow from 10.0.2.15
+    Allow from 127.0.0.1
+    Allow from 127.0.0.1
+    Allow from ::1
 
 </Directory>
 
@@ -234,25 +144,23 @@ AccessFileName .htaccess
 
 <IfVersion < 2.4>
 # Default: text/plain
-DefaultType <%= @defaulttype %>
+DefaultType text/plain
 </IfVersion>
 HostnameLookups Off
 
 # Default: on
-EnableMMAP <%= @enablemmap ? 'On' : 'Off' %>
+EnableMMAP On
 
 # Default: on
-EnableSendfile <%= @enablesendfile ? 'On' : 'Off' %>
+EnableSendfile On
 
-ErrorLog syslog:<%= @logfacility %>
+ErrorLog syslog:local6
 
-LogLevel <%= @httpd_loglevel %>
+LogLevel warn
 
-<% unless @logformat.empty? -%>
-LogFormat "<%= @logformat %>" custom
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" custom
 
 CustomLog "|/bin/logger -thttpd -plocal6.notice" custom
-<% end -%>
 
 ServerSignature Off
 
@@ -263,12 +171,10 @@ Alias /icons/ "/var/www/icons/"
     AllowOverride None
     Order allow,deny
     Allow from ::1
-<% scope.call_function('simplib::ipaddresses',[]).each do |t_iface| -%>
-    Allow from <%= t_iface %>
-<% end -%>
-<% if t_allowroot -%>
-<%= t_allowroot %>
-<% end -%>
+    Allow from 10.0.2.15
+    Allow from 127.0.0.1
+    Allow from 127.0.0.1
+    Allow from ::1
 </Directory>
 
 <Directory "/var/www/cgi-bin">
@@ -276,12 +182,10 @@ Alias /icons/ "/var/www/icons/"
     Options +ExecCGI -FollowSymLinks
     Order allow,deny
     Allow from ::1
-<% scope.call_function('simplib::ipaddresses',[]).each do |t_iface| -%>
-    Allow from <%= t_iface %>
-<% end -%>
-<% if t_allowroot -%>
-<%= t_allowroot %>
-<% end -%>
+    Allow from 10.0.2.15
+    Allow from 127.0.0.1
+    Allow from 127.0.0.1
+    Allow from ::1
 </Directory>
 
 IndexOptions FancyIndexing VersionSort NameWidth=*


### PR DESCRIPTION
- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
  Puppet 3 function.
- Use simplib::nets2cidr in simp_apache::munge_httpd_networks in
  in lieu of nets2cidr(), a deprecated simplib Puppet 3 function.
- Use simplib::ipaddresses in lieu of ipaddresses(), a deprecated
  simplib Puppet 3 function.

SIMP-6110 #comment pupmod-simp-simp_apache