### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
   in lieu of nets2cidr(), a deprecated simplib Puppet 3 function.
 - Use simplib::ipaddresses in lieu of ipaddresses(), a deprecated
   simplib Puppet 3 function.
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
 
 * Fri Oct 12 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Added $package_ensure parameters to simp_apache::install

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-simp_apache