### PR TITLE
 (SIMP-5311) Correctly purge conf and conf.d folders in /etc/httpd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com - 6.1.3-0
+- Added command to force purging of the conf/ and conf.d/ folders in
+  /etc/httpd.
+
 * Thu Mar 21 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 6.1.2-0
 - Removed unnecessary bracketize function
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com - 6.1.3-0
+* Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.3-0
 - Added command to force purging of the conf/ and conf.d/ folders in
   /etc/httpd.
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -82,6 +82,7 @@ class simp_apache::conf (
     mode     => '0640',
     recurse  => true,
     purge    => $purge,
+    force    => $purge,
     checksum => undef
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_apache",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",


### PR DESCRIPTION
simp_apache was not correctly purging the conf and conf.d folders due to
the default of force => false. force now matches purge and is set by
$purge.