### PR TITLE
(SIMP-6329) Removed ability to listen on port 80

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Mar 29 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.4-0
+- Removed ability to listen on port 80 from conf.pp and
+  httpd.conf.erb.
+
 * Mon Mar 25 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.3-0
 - Added command to force purging of the conf/ and conf.d/ folders in
   /etc/httpd.

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -12,12 +12,6 @@
 #   The LogLevel variable. Renamed to not conflict with the Puppet
 #   reserved word 'loglevel'.
 #
-# @param listen
-#   An array of ports upon which Apache should listen.
-#
-#   NOTE: If you are using an IPv6 with a port, you need to
-#     bracket the address
-#
 # @param firewall
 #   Whether or not to use the SIMP IPTables module.
 #
@@ -50,7 +44,6 @@ class simp_apache::conf (
   Integer                                            $worker_maxsparethreads      = 75,
   Integer                                            $worker_threadsperchild      = 25,
   Integer                                            $worker_maxrequestsperchild  = 0,
-  Array[Variant[Simplib::Host::Port, Simplib::Port]] $listen                      = [80],
   Optional[Array[String]]                            $includes                    = undef,
   String                                             $serveradmin                 = 'root@localhost',
   Optional[String]                                   $servername                  = undef,
@@ -92,16 +85,6 @@ class simp_apache::conf (
     mode    => '0640',
     content => template("${module_name}/etc/httpd/conf/httpd.conf.erb"),
     notify  => Service['httpd']
-  }
-
-  if $firewall {
-    include '::iptables'
-
-    iptables::listen::tcp_stateful { 'allow_http':
-      order        => 11,
-      trusted_nets => $l_allowroot,
-      dports       => $listen
-    }
   }
 
   if $syslog  {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_apache",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "author": "SIMP Team",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -27,14 +27,6 @@ describe 'simp_apache::conf' do
           end
         end
 
-        context 'firewall = true' do
-          let(:params){{ 'firewall' => true }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('iptables') }
-          it { is_expected.to create_class('simp_apache::conf') }
-          it { is_expected.to create_iptables__listen__tcp_stateful('allow_http') }
-        end
-
         context 'syslog = true' do
           let(:params){{ 'syslog' => true }}
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/expected/httpd.conf_default_el6
+++ b/spec/classes/expected/httpd.conf_default_el6
@@ -47,9 +47,6 @@ ThreadsPerChild      25
 MaxRequestsPerChild  0
 </IfModule>
 
-# Default: 80
-Listen 80
-
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule include_module modules/mod_include.so

--- a/spec/classes/expected/httpd.conf_default_el7
+++ b/spec/classes/expected/httpd.conf_default_el7
@@ -47,9 +47,6 @@ ThreadsPerChild      25
 MaxRequestsPerChild  0
 </IfModule>
 
-# Default: 80
-Listen 80
-
 Include conf.modules.d/*.conf
 
 Include conf.d/*.conf

--- a/templates/etc/httpd/conf/httpd.conf.erb
+++ b/templates/etc/httpd/conf/httpd.conf.erb
@@ -55,11 +55,6 @@ ThreadsPerChild      <%= @worker_threadsperchild %>
 MaxRequestsPerChild  <%= @worker_maxrequestsperchild %>
 </IfModule>
 
-# Default: 80
-<% @listen.flatten.each do |l| -%>
-Listen <%= l %>
-<% end -%>
-
 <% if (['RedHat','CentOS','OracleLinux'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'7']) < 0 -%>
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so


### PR DESCRIPTION
Removed ability to listen on port 80 from conf.pp and httpd.conf.erb.
The server still listens on port 443.