### PR TITLE
Avoid updating passed parameters.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jul 17 2019 Robert Vincent <pillarsdotnet@gmail.com> - 6.2.0-0
+- Ensure that the simp_apache::munge_httpd_networks does not attempt to modify
+  passed parameters.
+
 * Thu Jun 06 2019 Steven Pritchard <steven.pritchard@onypoint.com> - 6.2.0-0
 - Add v2 compliance_markup data
 - Drop support for Puppet 4

--- a/lib/puppet/functions/simp_apache/munge_httpd_networks.rb
+++ b/lib/puppet/functions/simp_apache/munge_httpd_networks.rb
@@ -16,10 +16,10 @@ Puppet::Functions.create_function(:'simp_apache::munge_httpd_networks') do
 
   def munge_httpd_networks(networks)
     httpd_networks = []
-    networks.flatten.each do |x|
-      next if x.nil?
+    networks.flatten.each do |net|
+      next if net.nil?
 
-      x.strip!
+      x = net.strip
       next if x.empty?
 
       #TODO what about IPv6 addresses?


### PR DESCRIPTION
Without this patch, I get the following error on Puppet-6:

> Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, can't modify frozen String (file: /etc/puppetlabs/code/environments/dev/modules/simp_apache/manifests/conf.pp, line: 74, column: 18) on node cusdpupcse01.internal.cnngad.com
