### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 7.5.0
+- [puppetsync] Add EL9 support
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 7.4.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 7.5.0
-- [puppetsync] Add EL9 support
+* Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 7.5.0
+- [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 7.4.0
 - [puppetsync] Updates for Puppet 8

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_apache",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "author": "SIMP Team",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",
@@ -55,33 +55,38 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.